### PR TITLE
Issue #10 - Large images overflow block settings panel

### DIFF
--- a/src/blocks/image-comparison/styles/editor.scss
+++ b/src/blocks/image-comparison/styles/editor.scss
@@ -1,3 +1,8 @@
 .wp-block-bigbite-image-comparison__divider {
   pointer-events: auto;
 }
+
+.components-panel .wp-block-bigbite-image-comparison-item__settings img {
+  height: auto;
+  max-width: 100%;
+}


### PR DESCRIPTION
## Description

Addresses [Issue 10](https://github.com/bigbite/image-comparison/issues/10) - When adding large images to the image comparison block, the images would overflow the available area in the block settings panel. This change addresses that bug by assigning a `max-width` to the image elements to contain the width, and also `height: auto` to retain image ratio.

## Change Log

- `editor.scss` - addition of css

## Steps to test

- Add an image comparison block to a page
- Assign a large image / two large images to the block
- Select an image and ensure it is contained to the block settings panel dimentions

## Screenshots/Videos

[Demo showing image contained within block settings panel](http://bigbite.im/v/EPMYF0)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
