### PR TITLE
Issue #8 - Any mouse button triggers divider dragging 

### DIFF
--- a/src/blocks/image-comparison/frontend.js
+++ b/src/blocks/image-comparison/frontend.js
@@ -29,9 +29,9 @@ if (imageComparisonBlocks?.length > 0) {
     /**
      * Array of allowed mouse buttons
      *
-     * 0 = left click
+     * 0 = primary click
      * 1 = middle click
-     * 2 = right click
+     * 2 = secondary click
      * 3 = back button
      * 4 = forward button
      */


### PR DESCRIPTION
## Description

[#8](https://github.com/bigbite/image-comparison/issues/8) - This PR restricts the allowed mouse buttons available to use when interacting with the block's divider button. The restriction is to allow the primary mouse button only, other mouse buttons will interact with the website as normal and will not initiate the drag function on the block.

## Change Log

- `frontend.js` - including event object within `activateIsPointerDownState` function

## Steps to test

- Add at least one image comparison block to a page
- Visit the page on the front end and scroll to the image comparison block
- Move the mouse over the block and try clicking, and holding, different mouse buttons to move the divider line
- Notice only the primary mouse button allows the divider to be moved
- To change the primary mouse button on Mac, open `System Settings`, scroll to the bottom of the left panel and click on `Mouse`. From there, change the `Secondary click` option. Retest the mouse button interactions on the page with this setting changed.

## Screenshots/Videos

[Mouse button interaction demo](http://bigbite.im/v/2vLnYD) - In the demo, the black ring indicates a left click and the green ring indicates a right click. Other mouse buttons (middle, MB4, and MB5) don't display a circle around the mouse when used.
[Setting to change primary mouse click on Mac](http://bigbite.im/i/X3uQd2)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
