### PR TITLE
Issue #7 - Fast click-and-drag movement with a mouse can cause unexpected behaviour

### DIFF
--- a/src/blocks/image-comparison/frontend.js
+++ b/src/blocks/image-comparison/frontend.js
@@ -149,6 +149,9 @@ if (imageComparisonBlocks?.length > 0) {
     imageContainer.addEventListener('pointermove', (event) =>
       pointerController(event, imageComparisonBlock),
     );
+    imageContainer.addEventListener('pointerleave', (event) =>
+      pointerController(event, imageComparisonBlock),
+    );
 
     dividerButton.addEventListener('keydown', (event) =>
       keyboardController(event, imageComparisonBlock),


### PR DESCRIPTION
## Description

[Issue #7](https://github.com/bigbite/image-comparison/issues/7) - This PR tackles the inconsistent divider resting position when the users moves the mouse quickly in all directions. Taking advantage of the existing functions, the change simply adds an event listener for the `pointerleave` event to set the resting divider position at the extreme top, right, bottom, or left position based on the mouse position.

## Change Log

- `frontend.js` - adding event listener

## Steps to test

- Add multiple image comparison blocks to a page, ensuring both horizontal and vertical divider settings are used in the blocks
- Select the divider on a block and quickly move the mouse to extremes in each direction
- For blocks with a horizontal divider, when quickly exiting the top and bottom of the block, the divider will rest at either 0% or 100% on the y axis
- For blocks with a vertical divider, when quickly exiting the left and right of the block, the divider will rest at either 0% or 100% on the x axis

## Screenshots/Videos

[Demo showing extreme mouse movements across image comparison blocks](http://bigbite.im/v/kxO8Hi)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
