### PR TITLE
Add wp-env support for development

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["."],
+  "lifecycleScripts": {
+    "afterStart": "npm run env run cli wp plugin activate image-comparison"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ When installing to your site, add the following to your `composer.json` file. Th
 ```
 
 ### Local Development or Manual Install
-Clone the repository into your `plugins` or `client-mu-plugins` directory.
+Clone the repository into your `plugins` or `client-mu-plugins` directory.  
+**NB**: If you have access to [Docker](https://www.docker.com/), you can spin up a local development environment using [wp-env](https://github.com/WordPress/gutenberg/tree/trunk/packages/env), in which case you may clone the repository into any directory.
 ```
 git clone git@github.com:bigbite/image-comparison.git && cd image-comparison
 ```
@@ -50,7 +51,7 @@ Install JS packages.
 npm install
 ```
 
-Build all assets
+Build all assets.
 ```
 npm run build:dev
 ```
@@ -59,6 +60,8 @@ Install PHP packages and create autoloader for the plugin.
 ```
 composer install
 ```
+
+If using wp-env, you can run its commands by running `npm run env [command]`.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "scripts": {
         "build:prod": "build-tools build --production --once",
         "build:dev": "build-tools build --once",
-        "watch:dev": "build-tools build"
+        "watch:dev": "build-tools build",
+        "env": "npx @wordpress/env"
     },
     "dependencies": {
         "@wordpress/block-editor": "^13.0.0",


### PR DESCRIPTION
## Description
Adds wp-env configuration, npm script passthrough, and updates the documentation accordingly.

## Change Log
- Add wp-env support

## Steps to test
1. Boot Docker
2. Run `npm run env start`
3. Once the command has completed, you should be able to visit http://localhost:8888 to see a WP install
4. Log into the admin with credentials `admin`:`password`
5. Visit the plugins screen
6. Image Comparison should be activated

## Screenshots/Videos

![screenshot showing terminal output from wp-env](http://bigbite.im/i/IRn2pL+)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
