### PR TITLE
[28][29][31] Width and Height block settings

### DIFF
--- a/inc/blocks/image-comparison/block.json
+++ b/inc/blocks/image-comparison/block.json
@@ -83,11 +83,11 @@
         },
         "containerHeight": {
             "type": "string",
-            "default": null
+            "default": "auto"
         },
         "containerWidth": {
             "type": "string",
-            "default": null
+            "default": "auto"
         }
     },
     "supports": {

--- a/inc/blocks/image-comparison/block.json
+++ b/inc/blocks/image-comparison/block.json
@@ -83,11 +83,11 @@
         },
         "containerHeight": {
             "type": "string",
-            "default": "500px"
+            "default": null
         },
         "containerWidth": {
             "type": "string",
-            "default": "500px"
+            "default": null
         }
     },
     "supports": {

--- a/inc/blocks/image-comparison/render.php
+++ b/inc/blocks/image-comparison/render.php
@@ -54,8 +54,8 @@ $extra_styles[] = sprintf( '--bigbite-image-comparison-divider-box-width: %s;', 
 $extra_styles[] = sprintf( '--bigbite-image-comparison-divider-box-height: %s;', $attributes['dividerBoxHeight'] );
 $extra_styles[] = sprintf( '--bigbite-image-comparison-divider-box-border-radius: %s;', $attributes['dividerBoxBorderRadius']['top'] );
 $extra_styles[] = sprintf( '--bigbite-image-comparison-divider-icon-gap: %s;', $attributes['dividerIconGap'] );
-$extra_styles[] = sprintf( '--bigbite-image-comparison-container-height: %s;', $attributes['containerHeight'] );
-$extra_styles[] = sprintf( '--bigbite-image-comparison-container-width: %s;', $attributes['containerWidth'] );
+$extra_styles[] = sprintf( '--bigbite-image-comparison-container-height: %s;', $attributes['align'] ? 'auto' : $attributes['containerHeight'] );
+$extra_styles[] = sprintf( '--bigbite-image-comparison-container-width: %s;', $attributes['align'] ? 'auto' : $attributes['containerWidth'] );
 
 foreach ( $colours as $colour ) {
 	if ( ( empty( $attributes[ $colour[0] ] ) && empty( $attributes[ $colour[1] ] ) ) || ! $colour[3] ) {

--- a/inc/blocks/image-comparison/render.php
+++ b/inc/blocks/image-comparison/render.php
@@ -54,8 +54,8 @@ $extra_styles[] = sprintf( '--bigbite-image-comparison-divider-box-width: %s;', 
 $extra_styles[] = sprintf( '--bigbite-image-comparison-divider-box-height: %s;', $attributes['dividerBoxHeight'] );
 $extra_styles[] = sprintf( '--bigbite-image-comparison-divider-box-border-radius: %s;', $attributes['dividerBoxBorderRadius']['top'] );
 $extra_styles[] = sprintf( '--bigbite-image-comparison-divider-icon-gap: %s;', $attributes['dividerIconGap'] );
-$extra_styles[] = sprintf( '--bigbite-image-comparison-container-height: %s;', $attributes['align'] ? 'auto' : $attributes['containerHeight'] );
-$extra_styles[] = sprintf( '--bigbite-image-comparison-container-width: %s;', $attributes['align'] ? 'auto' : $attributes['containerWidth'] );
+$extra_styles[] = sprintf( '--bigbite-image-comparison-container-height: %s;', $attributes['containerHeight'] );
+$extra_styles[] = sprintf( '--bigbite-image-comparison-container-width: %s;', $attributes['containerWidth'] );
 
 foreach ( $colours as $colour ) {
 	if ( ( empty( $attributes[ $colour[0] ] ) && empty( $attributes[ $colour[1] ] ) ) || ! $colour[3] ) {

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -53,8 +53,8 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
    * applied if these values have not been specifically set by a user.
    *
    * @returns {
-   *  width: string|undefined
-   *  height: string|undefined
+   *  width: string
+   *  height: string
    * } The size containing the height and width of the block's container.
    */
   const getContainerSize = () => {

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -53,8 +53,8 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
    * applied if these values have not been specifically set by a user.
    *
    * @returns {
-   *  width: string|undefined The container's width.
-   *  height: string|undefined The container's height.
+   *  width: string|undefined
+   *  height: string|undefined
    * } The size containing the height and width of the block's container.
    */
   const getContainerSize = () => {

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -51,9 +51,32 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
    * Overwrite the default size of the block with the theme's
    * defined contentSize, if it exists. This should only be
    * applied if these values have not been specifically set by a user.
+   *
+   * @returns {
+   *  width: string|undefined The container's width.
+   *  height: string|undefined The container's height.
+   * } The size containing the height and width of the block's container.
    */
-  const containerHeight = attributes.containerHeight ?? '500px';
-  const containerWidth = attributes.containerWidth ?? contentWidth ?? '500px';
+  const getContainerSize = () => {
+    let containerHeight = '500px';
+    if (attributes.containerHeight) {
+      containerHeight = attributes.containerHeight;
+    }
+
+    let containerWidth = '500px';
+    if (attributes.containerWidth) {
+      containerWidth = attributes.containerWidth;
+    } else if (contentWidth) {
+      containerWidth = contentWidth;
+    }
+
+    return {
+      containerHeight,
+      containerWidth,
+    };
+  };
+
+  const { containerHeight, containerWidth } = getContainerSize();
 
   const innerBlockSettings = {
     template: [['bigbite/image-comparison-item'], ['bigbite/image-comparison-item']],

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -102,14 +102,19 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
   const [{ innerBlocks }] = wp.data.select('core/block-editor').getBlocksByClientId(clientId);
 
   /**
-   * Determine whether to allow the resize handles to be
-   * displayed based on if an image is assigned or not
+   * Don't display resize handles if the user has chosen one of the alignment settings.
    */
-  innerBlocks.forEach((block) => {
-    if (block?.attributes?.id) {
-      shouldDisplayResize = true;
-    }
-  });
+  if (!attributes.align) {
+    /**
+     * Determine whether to allow the resize handles to be
+     * displayed based on if an image is assigned or not
+     */
+    innerBlocks.forEach((block) => {
+      if (block?.attributes?.id) {
+        shouldDisplayResize = true;
+      }
+    });
+  }
 
   /**
    * Only ever display the right, bottom, and bottomRight handles

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -95,37 +95,45 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
     topRight: false,
   };
 
-  const blockProps = useBlockProps({
-    style: {
-      '--bigbite-image-comparison-overflow': overflow ? 'visible' : 'hidden',
-      '--bigbite-image-comparison-divider-initial-position': dividerInitialPosition,
-      '--bigbite-image-comparison-divider-thickness': dividerThickness,
-      '--bigbite-image-comparison-divider-box-width': dividerBoxWidth,
-      '--bigbite-image-comparison-divider-box-height': dividerBoxHeight,
-      '--bigbite-image-comparison-divider-box-border-radius': dividerBoxBorderRadius?.top,
-      '--bigbite-image-comparison-divider-icon-gap': dividerIconGap,
-      '--bigbite-image-comparison-divider-colour': dividerColour
-        ? `var( --wp--preset--color--${dividerColour}, ${customDividerColour} )`
-        : customDividerColour,
-      '--bigbite-image-comparison-divider-box-colour': dividerBoxColour
-        ? `var( --wp--preset--color--${dividerBoxColour}, ${customDividerBoxColour} )`
-        : customDividerBoxColour,
-      '--bigbite-image-comparison-divider-icon-colour': dividerIconColour
-        ? `var( --wp--preset--color--${dividerIconColour}, ${customDividerIconColour} )`
-        : customDividerIconColour,
-      '--bigbite-image-comparison-caption-text-colour': captionTextColour
-        ? `var( --wp--preset--color--${captionTextColour}, ${customCaptionTextColour} )`
-        : customCaptionTextColour,
-      '--bigbite-image-comparison-caption-background-colour': captionBackgroundColour
-        ? `var( --wp--preset--color--${captionBackgroundColour}, ${customCaptionBackgroundColour} )`
-        : customCaptionBackgroundColour,
-      '--bigbite-image-comparison-container-height': containerHeight,
-      '--bigbite-image-comparison-container-width': containerWidth,
-    },
-    className: {
-      'wp-block-bigbite-image-comparison--horizontal': dividerAxis === 'horizontal',
-    },
-  });
+  /**
+   * Generates the block props.
+   *
+   * @returns the block props.
+   */
+  const getBlockProps = () =>
+    useBlockProps({
+      style: {
+        '--bigbite-image-comparison-overflow': overflow ? 'visible' : 'hidden',
+        '--bigbite-image-comparison-divider-initial-position': dividerInitialPosition,
+        '--bigbite-image-comparison-divider-thickness': dividerThickness,
+        '--bigbite-image-comparison-divider-box-width': dividerBoxWidth,
+        '--bigbite-image-comparison-divider-box-height': dividerBoxHeight,
+        '--bigbite-image-comparison-divider-box-border-radius': dividerBoxBorderRadius?.top,
+        '--bigbite-image-comparison-divider-icon-gap': dividerIconGap,
+        '--bigbite-image-comparison-divider-colour': dividerColour
+          ? `var( --wp--preset--color--${dividerColour}, ${customDividerColour} )`
+          : customDividerColour,
+        '--bigbite-image-comparison-divider-box-colour': dividerBoxColour
+          ? `var( --wp--preset--color--${dividerBoxColour}, ${customDividerBoxColour} )`
+          : customDividerBoxColour,
+        '--bigbite-image-comparison-divider-icon-colour': dividerIconColour
+          ? `var( --wp--preset--color--${dividerIconColour}, ${customDividerIconColour} )`
+          : customDividerIconColour,
+        '--bigbite-image-comparison-caption-text-colour': captionTextColour
+          ? `var( --wp--preset--color--${captionTextColour}, ${customCaptionTextColour} )`
+          : customCaptionTextColour,
+        '--bigbite-image-comparison-caption-background-colour': captionBackgroundColour
+          ? `var( --wp--preset--color--${captionBackgroundColour}, ${customCaptionBackgroundColour} )`
+          : customCaptionBackgroundColour,
+        '--bigbite-image-comparison-container-height': containerHeight,
+        '--bigbite-image-comparison-container-width': containerWidth,
+      },
+      className: {
+        'wp-block-bigbite-image-comparison--horizontal': dividerAxis === 'horizontal',
+      },
+    });
+
+  const blockProps = getBlockProps();
 
   const uniqueId = `fig-${clientId}`;
 

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -53,11 +53,18 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
    * applied if these values have not been specifically set by a user.
    *
    * @returns {
-   *  width: string|undefined
-   *  height: string|undefined
+   *  width: string
+   *  height: string
    * } The size containing the height and width of the block's container.
    */
   const getContainerSize = () => {
+    if (attributes.align) {
+      return {
+        containerWidth: 'auto',
+        containerHeight: 'auto',
+      };
+    }
+
     let containerHeight = '500px';
     if (attributes.containerHeight) {
       containerHeight = attributes.containerHeight;

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -3,6 +3,7 @@
  */
 import { ResizableBox } from '@wordpress/components';
 import { useInnerBlocksProps, useBlockProps, useSettings } from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
   const [contentWidth] = useSettings('layout.contentSize');
 
   const {
+    align,
     overflow,
     dividerInitialPosition,
     dividerAxis,
@@ -61,14 +63,31 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
   let shouldDisplayResize = false;
 
   /**
+   * Overwrite the default size of the block with the theme's
+   * defined contentSize, if it exists. This should only be
+   * applied if no images have been added to the block.
+   */
+  useEffect(() => {
+    if (!shouldDisplayResize) {
+      setAttributes({ containerWidth: contentWidth });
+    }
+  }, [contentWidth]);
+
+  useEffect(() => {
+    if (['wide', 'full'].includes(align)) {
+      setAttributes({
+        containerHeight: 'auto',
+        containerWidth: 'auto',
+      });
+    }
+  }, [align, setAttributes]);
+
+  /**
    * Retrieve the inner blocks
    */
   const [{ innerBlocks }] = wp.data.select('core/block-editor').getBlocksByClientId(clientId);
 
-  /**
-   * Don't display resize handles if the user has chosen one of the alignment settings.
-   */
-  if (!attributes.align) {
+  if (!['wide', 'full'].includes(align)) {
     /**
      * Determine whether to allow the resize handles to be
      * displayed based on if an image is assigned or not

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -3,7 +3,6 @@
  */
 import { ResizableBox } from '@wordpress/components';
 import { useInnerBlocksProps, useBlockProps, useSettings } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -46,9 +45,15 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
     customCaptionTextColour,
     captionBackgroundColour,
     customCaptionBackgroundColour,
-    containerHeight,
-    containerWidth,
   } = attributes;
+
+  /**
+   * Overwrite the default size of the block with the theme's
+   * defined contentSize, if it exists. This should only be
+   * applied if these values have not been specifically set by a user.
+   */
+  const containerHeight = attributes.containerHeight ?? '500px';
+  const containerWidth = attributes.containerWidth ?? contentWidth ?? '500px';
 
   const innerBlockSettings = {
     template: [['bigbite/image-comparison-item'], ['bigbite/image-comparison-item']],
@@ -60,17 +65,6 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
    * Initially set the resize handles to be hidden
    */
   let shouldDisplayResize = false;
-
-  /**
-   * Overwrite the default size of the block with the theme's
-   * defined contentSize, if it exists. This should only be
-   * applied if no images have been added to the block.
-   */
-  useEffect(() => {
-    if (!shouldDisplayResize) {
-      setAttributes({ containerWidth: contentWidth });
-    }
-  }, [contentWidth]);
 
   /**
    * Retrieve the inner blocks

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -45,45 +45,9 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
     customCaptionTextColour,
     captionBackgroundColour,
     customCaptionBackgroundColour,
+    containerHeight,
+    containerWidth,
   } = attributes;
-
-  /**
-   * Get the container's size. If this has not been set by
-   * the user then we overwrite the default size of the block
-   * with the theme's defined contentSize, if it exists.
-   *
-   * @returns {
-   *  width: string
-   *  height: string
-   * } The size containing the height and width of the block's container.
-   */
-  const getContainerSize = () => {
-    if (attributes.align) {
-      return {
-        containerWidth: 'auto',
-        containerHeight: 'auto',
-      };
-    }
-
-    let containerHeight = '500px';
-    if (attributes.containerHeight) {
-      containerHeight = attributes.containerHeight;
-    }
-
-    let containerWidth = '500px';
-    if (attributes.containerWidth) {
-      containerWidth = attributes.containerWidth;
-    } else if (contentWidth) {
-      containerWidth = contentWidth;
-    }
-
-    return {
-      containerHeight,
-      containerWidth,
-    };
-  };
-
-  const { containerHeight, containerWidth } = getContainerSize();
 
   const innerBlockSettings = {
     template: [['bigbite/image-comparison-item'], ['bigbite/image-comparison-item']],

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -95,45 +95,37 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
     topRight: false,
   };
 
-  /**
-   * Generates the block props.
-   *
-   * @returns the block props.
-   */
-  const getBlockProps = () =>
-    useBlockProps({
-      style: {
-        '--bigbite-image-comparison-overflow': overflow ? 'visible' : 'hidden',
-        '--bigbite-image-comparison-divider-initial-position': dividerInitialPosition,
-        '--bigbite-image-comparison-divider-thickness': dividerThickness,
-        '--bigbite-image-comparison-divider-box-width': dividerBoxWidth,
-        '--bigbite-image-comparison-divider-box-height': dividerBoxHeight,
-        '--bigbite-image-comparison-divider-box-border-radius': dividerBoxBorderRadius?.top,
-        '--bigbite-image-comparison-divider-icon-gap': dividerIconGap,
-        '--bigbite-image-comparison-divider-colour': dividerColour
-          ? `var( --wp--preset--color--${dividerColour}, ${customDividerColour} )`
-          : customDividerColour,
-        '--bigbite-image-comparison-divider-box-colour': dividerBoxColour
-          ? `var( --wp--preset--color--${dividerBoxColour}, ${customDividerBoxColour} )`
-          : customDividerBoxColour,
-        '--bigbite-image-comparison-divider-icon-colour': dividerIconColour
-          ? `var( --wp--preset--color--${dividerIconColour}, ${customDividerIconColour} )`
-          : customDividerIconColour,
-        '--bigbite-image-comparison-caption-text-colour': captionTextColour
-          ? `var( --wp--preset--color--${captionTextColour}, ${customCaptionTextColour} )`
-          : customCaptionTextColour,
-        '--bigbite-image-comparison-caption-background-colour': captionBackgroundColour
-          ? `var( --wp--preset--color--${captionBackgroundColour}, ${customCaptionBackgroundColour} )`
-          : customCaptionBackgroundColour,
-        '--bigbite-image-comparison-container-height': containerHeight,
-        '--bigbite-image-comparison-container-width': containerWidth,
-      },
-      className: {
-        'wp-block-bigbite-image-comparison--horizontal': dividerAxis === 'horizontal',
-      },
-    });
-
-  const blockProps = getBlockProps();
+  const blockProps = useBlockProps({
+    style: {
+      '--bigbite-image-comparison-overflow': overflow ? 'visible' : 'hidden',
+      '--bigbite-image-comparison-divider-initial-position': dividerInitialPosition,
+      '--bigbite-image-comparison-divider-thickness': dividerThickness,
+      '--bigbite-image-comparison-divider-box-width': dividerBoxWidth,
+      '--bigbite-image-comparison-divider-box-height': dividerBoxHeight,
+      '--bigbite-image-comparison-divider-box-border-radius': dividerBoxBorderRadius?.top,
+      '--bigbite-image-comparison-divider-icon-gap': dividerIconGap,
+      '--bigbite-image-comparison-divider-colour': dividerColour
+        ? `var( --wp--preset--color--${dividerColour}, ${customDividerColour} )`
+        : customDividerColour,
+      '--bigbite-image-comparison-divider-box-colour': dividerBoxColour
+        ? `var( --wp--preset--color--${dividerBoxColour}, ${customDividerBoxColour} )`
+        : customDividerBoxColour,
+      '--bigbite-image-comparison-divider-icon-colour': dividerIconColour
+        ? `var( --wp--preset--color--${dividerIconColour}, ${customDividerIconColour} )`
+        : customDividerIconColour,
+      '--bigbite-image-comparison-caption-text-colour': captionTextColour
+        ? `var( --wp--preset--color--${captionTextColour}, ${customCaptionTextColour} )`
+        : customCaptionTextColour,
+      '--bigbite-image-comparison-caption-background-colour': captionBackgroundColour
+        ? `var( --wp--preset--color--${captionBackgroundColour}, ${customCaptionBackgroundColour} )`
+        : customCaptionBackgroundColour,
+      '--bigbite-image-comparison-container-height': containerHeight,
+      '--bigbite-image-comparison-container-width': containerWidth,
+    },
+    className: {
+      'wp-block-bigbite-image-comparison--horizontal': dividerAxis === 'horizontal',
+    },
+  });
 
   const uniqueId = `fig-${clientId}`;
 

--- a/src/blocks/image-comparison/components/Edit.js
+++ b/src/blocks/image-comparison/components/Edit.js
@@ -48,9 +48,9 @@ const Edit = ({ attributes, setAttributes, clientId }) => {
   } = attributes;
 
   /**
-   * Overwrite the default size of the block with the theme's
-   * defined contentSize, if it exists. This should only be
-   * applied if these values have not been specifically set by a user.
+   * Get the container's size. If this has not been set by
+   * the user then we overwrite the default size of the block
+   * with the theme's defined contentSize, if it exists.
    *
    * @returns {
    *  width: string


### PR DESCRIPTION
## Description

Fixes https://github.com/bigbite/image-comparison/issues/28, https://github.com/bigbite/image-comparison/issues/29 & https://github.com/bigbite/image-comparison/issues/31

Assigns the Image Comparisons `containerHeight` and `containerWidth` values a default of `null`. This is to avoid an issue where the block won't scale to the new width if the `settings.layout.contentSize` setting in `theme.json` is changed and the user has not set a width yet.

Fixes an issue where the alignment options in the block toolbar have no effect due to it being overridden by the `containerHeight` and `containerWidth` attribute styles that are passed into the `ResizableBox` component.  Instead, we now set the `containerWidth` and `containerHeight` to `auto` if the alignment attribute has been set.


## Change Log

- Fixes an issue where `containerHeight` and `containerWidth` values not specifically set the by user would not scale when the `settings.layout.contentSize` setting in theme.json would change.
- Fixes an issue where the alignment options in the block toolbar have no effect.

## Steps to test

### Issue https://github.com/bigbite/image-comparison/issues/28

1. Add an Image Comparison block
2. Add both images
3. Save
4. Increase the settings.layout.contentSize value in theme.json
5. Refresh page
6. See that the Image Comparison block is now displaying correctly in the editor and on the frontend


### Issue https://github.com/bigbite/image-comparison/issues/29

1. Add an Image Comparison block
2. Add both images
3. Apply a settings.layout alignment value
4. The width and height settings within the block sidebar should disappear.
5. The alignment of the block should be reflected correctly both within the editor and on the frontend.

## Screenshots/Videos

http://bigbite.im/v/KfN5NC (https://github.com/bigbite/image-comparison/issues/28)

http://bigbite.im/v/3piqUx (https://github.com/bigbite/image-comparison/issues/29)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
