### PR TITLE
[36] add composer.json to build

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -7,7 +7,6 @@ package.json
 # composer
 
 composer.lock
-composer.json
 
 # build tools
 


### PR DESCRIPTION
## Description
[36](https://github.com/bigbite/image-comparison/issues/36) - When adding the plugin to a site the composer file wasn't finding the branch `main-built` this is because the `main-built` branch doesn't have a composer.json file. When a repository includes a composer.json file, it defines aspects of itself that are important to how Composer manages the package and if it can't find a composer.json file it just ignores that branch.

## Change Log

<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->

- Removed composer.json from the .deployignore file


## Steps to test
Add the following to your composer.json file on a project which doesn't have the plugin currently

```
"repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/bigbite/image-comparison.git"
        }
	],
    "require": {
    "composer/installers": "^2.0",
    "bigbite/image-comparison": "dev-chore/update-ci-built"
	},
	"extra": {
    "installer-paths": {
      "plugins/{$name}/": [
        "type:wordpress-plugin"
      ]
    }
  },
  "config": {
    "preferred-install": "dist",
    "allow-plugins": {
      "composer/installers": true
    }
  }
```

then run `composer install ` 

Once this is merged `main-built` will have the composer.json file and the instructions in the readme will work correctly.


## Screenshots/Videos
http://bigbite.im/i/XKilri
## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
