### PR TITLE
Release 1.0.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bigbite/bigbite-image-comparison",
-    "version": "0.0.2",
+    "version": "1.0.0-beta.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@bigbite/bigbite-image-comparison",
-            "version": "0.0.2",
+            "version": "1.0.0-beta.2",
             "dependencies": {
                 "@wordpress/block-editor": "^13.0.0",
                 "@wordpress/blocks": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@bigbite/bigbite-image-comparison",
     "description": "Display two images in a comparison state.",
-    "version": "0.0.2",
+    "version": "1.0.0-beta.2",
     "author": "Big Bite",
     "prettier": "@bigbite/build-tools/configs/prettier",
     "scripts": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Image Comparison
  * Description:       Display two images in a comparison state.
- * Version:           1.0.0-beta.1
+ * Version:           1.0.0-beta.2
  * Requires at least: 6.3
  * Requires PHP:      8.2
  * Author:            Big Bite®


### PR DESCRIPTION
Bumps version numbers for `1.0.0-beta.2` release, and aligns package.json version with plugin version