### PR TITLE
[44] - Unable to scroll past block on mobile

### DIFF
--- a/src/blocks/image-comparison/frontend.js
+++ b/src/blocks/image-comparison/frontend.js
@@ -62,19 +62,15 @@ if (imageComparisonBlocks?.length > 0) {
       'wp-block-bigbite-image-comparison--horizontal',
     );
 
-    const client = hasHorizontalAxisDivider ? event?.clientY : event?.clientX;
-    const targetDOMRect = event?.target?.getBoundingClientRect();
-    const targetPositionOffset = hasHorizontalAxisDivider ? targetDOMRect?.y : targetDOMRect?.x;
-    let position =
-      ((client - targetPositionOffset) /
-        (hasHorizontalAxisDivider ? targetDOMRect?.height : targetDOMRect?.width)) *
-      100;
+    const containerRect = imageContainer.getBoundingClientRect();
+    const client = hasHorizontalAxisDivider ? event.clientY : event.clientX;
+    const offset = hasHorizontalAxisDivider ? containerRect.y : containerRect.x;
+    const size = hasHorizontalAxisDivider ? containerRect.height : containerRect.width;
 
-    if (position < 0) {
-      position = 0;
-    } else if (position > 100) {
-      position = 100;
-    }
+    let position = ((client - offset) / size) * 100;
+
+    if (position < 0) position = 0;
+    if (position > 100) position = 100;
 
     imageComparisonBlock.style.setProperty(
       '--bigbite-image-comparison-divider-initial-position',
@@ -145,13 +141,62 @@ if (imageComparisonBlocks?.length > 0) {
       '.wp-block-bigbite-image-comparison__divider button',
     );
 
-    imageContainer.addEventListener('pointerdown', (event) => activateIsPointerDownState(event));
-    imageContainer.addEventListener('pointermove', (event) =>
-      pointerController(event, imageComparisonBlock),
-    );
-    imageContainer.addEventListener('pointerleave', (event) =>
-      pointerController(event, imageComparisonBlock),
-    );
+    // Check if it's a touch device
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+
+    // If it's a touch device, only allow dragging from the divider button
+    if (isTouchDevice) {
+      dividerButton.addEventListener('pointerdown', (event) => {
+        activateIsPointerDownState(event);
+
+        /**
+         * Pointer move and up handlers
+         * @param {object} moveEvent pointermove event
+         * @param {object} upEvent pointerup event
+         *
+         */
+        const moveHandler = (moveEvent) => pointerController(moveEvent, imageComparisonBlock);
+
+        /**
+         * Pointer up handler
+         *
+         */
+        const upHandler = () => {
+          deactivateIsPointerDownState();
+          window.removeEventListener('pointermove', moveHandler);
+          window.removeEventListener('pointerup', upHandler);
+        };
+
+        window.addEventListener('pointermove', moveHandler);
+        window.addEventListener('pointerup', upHandler);
+      });
+    } else {
+      // If it's not a touch device, allow dragging from anywhere on the image
+      imageContainer.addEventListener('pointerdown', (event) => {
+        activateIsPointerDownState(event);
+
+        /**
+         * Pointer move and up handlers
+         * @param {object} moveEvent pointermove event
+         * @param {object} upEvent pointerup event
+         *
+         */
+        const moveHandler = (moveEvent) => pointerController(moveEvent, imageComparisonBlock);
+
+        /**
+         * Pointer up handler
+         *
+         */
+        const upHandler = () => {
+          deactivateIsPointerDownState();
+          window.removeEventListener('pointermove', moveHandler);
+          window.removeEventListener('pointerup', upHandler);
+        };
+
+        window.addEventListener('pointermove', moveHandler);
+        window.addEventListener('pointerup', upHandler);
+      });
+    }
 
     dividerButton.addEventListener('keydown', (event) =>
       keyboardController(event, imageComparisonBlock),

--- a/src/blocks/image-comparison/styles/frontend.scss
+++ b/src/blocks/image-comparison/styles/frontend.scss
@@ -5,3 +5,11 @@
 .wp-block-bigbite-image-comparison--horizontal .wp-block-bigbite-image-comparison__container {
   cursor: row-resize;
 }
+
+.wp-block-bigbite-image-comparison__divider button {
+  touch-action: pan-y;
+}
+
+.wp-block-bigbite-image-comparison--horizontal .wp-block-bigbite-image-comparison__divider button {
+  touch-action: pan-x;
+}

--- a/src/blocks/image-comparison/styles/shared.scss
+++ b/src/blocks/image-comparison/styles/shared.scss
@@ -4,7 +4,7 @@
 
 .wp-block-bigbite-image-comparison__container {
   max-width: 100%;
-  touch-action: none;
+  // touch-action: none;
   border: 0 !important;
   padding: 0 !important;
   line-height: 0 !important;
@@ -24,7 +24,7 @@
   display: inline-flex;
   position: absolute;
   align-items: center;
-  pointer-events: none;
+  // pointer-events: none;
   transform: translate(-50%, 0);
   left: calc(var(--bigbite-image-comparison-divider-initial-position) * 1%);
 
@@ -46,7 +46,7 @@
   padding: 8px;
   display: flex;
   align-items: center;
-  pointer-events: none;
+  // pointer-events: none;
   justify-content: center;
   background: var(--bigbite-image-comparison-divider-box-colour);
   gap: calc(var(--bigbite-image-comparison-divider-icon-gap) * 1px);

--- a/src/blocks/image-comparison/styles/shared.scss
+++ b/src/blocks/image-comparison/styles/shared.scss
@@ -4,7 +4,6 @@
 
 .wp-block-bigbite-image-comparison__container {
   max-width: 100%;
-  // touch-action: none;
   border: 0 !important;
   padding: 0 !important;
   line-height: 0 !important;
@@ -24,7 +23,6 @@
   display: inline-flex;
   position: absolute;
   align-items: center;
-  // pointer-events: none;
   transform: translate(-50%, 0);
   left: calc(var(--bigbite-image-comparison-divider-initial-position) * 1%);
 
@@ -46,7 +44,6 @@
   padding: 8px;
   display: flex;
   align-items: center;
-  // pointer-events: none;
   justify-content: center;
   background: var(--bigbite-image-comparison-divider-box-colour);
   gap: calc(var(--bigbite-image-comparison-divider-icon-gap) * 1px);


### PR DESCRIPTION
Issue: #44 

## Description
Fixes issue with block not being scrollable on touch devices.

On touch devices the block will now only work if the divider is clicked and dragged, on the images themselves the page will scroll, desktop functionality remains unchanged

## Change Log
- src/blocks/image-comparison/frontend.js - reworks JS to accommodate touch devices
- src/blocks/image-comparison/styles/frontend.scss - adds some specific touch actions
- src/blocks/image-comparison/styles/shared.scss - removes some pointer events and touch actions

## Steps to test
- Add a couple of image comparison blocks to a post with some more content
- Save and view the frontend on a mobile viewport
- You should be able to scroll the page as expected on mobile without the block taking the cursor focus
- UNLESS you click and drag the block divider, then the block should function as expected
- Repeat steps for both vertical and horizontal versions of the block
- Refresh and view on desktop, and block should still function as expected/previously

## Screenshots/Videos
http://bigbite.im/v/V6ffO5

### AI Usage (if applicable)
- I have GitHub Copilot set up to auto-complete in my IDE.
- I used ChatGPT to confirm my approach was the best solution. 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have disclosed all areas where AI assistance was used when creating this pull request, if applicable
- [x] AI code suggestions have been manually reviewed and I understand how they work
